### PR TITLE
Add installing project dependencies / uploading test results example to CI docs

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -51,8 +51,16 @@ steps:
       node-version: '14'
   - name: Install operating system dependencies
     run: npx playwright install-deps
+  - name: Install dependencies
+    run: npm install
   - name: Run your tests
     run: npm test
+  - name: Upload test results
+    if: always()
+    uses: actions/upload-artifact@v2
+    with:
+      name: playwright-results
+      path: test-results
 ```
 
 ```yml python

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -49,10 +49,10 @@ steps:
   - uses: actions/setup-node@v2
     with:
       node-version: '14'
-  - name: Install operating system dependencies
-    run: npx playwright install-deps
   - name: Install dependencies
-    run: npm install
+    run: npm ci
+  - name: Install Playwright
+    run: npx playwright install --with-deps
   - name: Run your tests
     run: npm test
   - name: Upload test results


### PR DESCRIPTION
It took me a bit of time to figure out an initial working GitHub Actions workflow (using the documented one as a starting point) and then I found a message about uploading test results in the Slack but felt nice if it would be documented / to save people time in the future.

I'm not a node expert but it seems like the example workflow doesn't include actually installing your project, although the Python example below it does? This might be obvious to others but I've added it as well as an example for uploading artifacts to GitHub for people that want to.